### PR TITLE
Refactor/dataform assertion name

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@devoteamgcloud'
+          scope: '@astercapital'
       - run: npm ci
       - run: npm publish
         env:

--- a/includes/referential_integrity_assertions.js
+++ b/includes/referential_integrity_assertions.js
@@ -23,14 +23,28 @@
 
 const assertions = [];
 
-const createReferentialIntegrityAssertion = (globalParams, parentSchema, parentTable, parentKey, parentFilter, childSchema, childTable, childKey, childFilter) => {
-
-  const assertion = assert(`assert_referential_integrity_${parentSchema}_${parentTable}_${childSchema}_${childTable}`)
+const createReferentialIntegrityAssertion = (
+  globalParams,
+  parentSchema,
+  parentTable,
+  parentKey,
+  parentFilter,
+  childSchema,
+  childTable,
+  childKey,
+  childFilter,
+) => {
+  const assertion = assert(
+    `${parentSchema}_${parentTable}_assertions_referential_integrity_${childSchema}_${childTable}`,
+  )
     .database(globalParams.database)
     .schema(globalParams.schema)
-    .description(`Check referential integrity for ${childTable}.${childKey} referencing ${parentTable}.${parentKey}`)
+    .description(
+      `Check referential integrity for ${childTable}.${childKey} referencing ${parentTable}.${parentKey}`,
+    )
     .tags("assert-referential-integrity")
-    .query(ctx => `
+    .query(
+      (ctx) => `
                 WITH
                     parent_filtering AS (
                         SELECT
@@ -54,11 +68,14 @@ const createReferentialIntegrityAssertion = (globalParams, parentSchema, parentT
                     FROM parent_filtering AS pt
                     LEFT JOIN child_filtering AS t ON t.${childKey} = pt.${parentKey}
                     WHERE t.${childKey} IS NULL
-        `);
+        `,
+    );
 
-  (globalParams.tags && globalParams.tags.forEach((tag) => assertion.tags(tag)));
+  globalParams.tags && globalParams.tags.forEach((tag) => assertion.tags(tag));
 
-  (globalParams.disabledInEnvs && globalParams.disabledInEnvs.includes(dataform.projectConfig.vars.env)) && assertion.disabled();
+  globalParams.disabledInEnvs &&
+    globalParams.disabledInEnvs.includes(dataform.projectConfig.vars.env) &&
+    assertion.disabled();
 
   assertions.push(assertion);
 };
@@ -70,26 +87,23 @@ module.exports = (globalParams, config, referentialIntegrityConditions) => {
       const relationships = parentTables[parentTable];
       const parentFilter = config[parentSchema]?.[parentTable]?.where ?? true;
 
-      relationships.forEach(({
-        parentKey,
-        childSchema,
-        childTable,
-        childKey
-      }) => {
-        const childFilter = config[childTable]?.where ?? true;
-        createReferentialIntegrityAssertion(
-          globalParams,
-          parentSchema,
-          parentTable,
-          parentKey,
-          parentFilter,
-          childSchema,
-          childTable,
-          childKey,
-          childFilter
-        );
-      })
+      relationships.forEach(
+        ({ parentKey, childSchema, childTable, childKey }) => {
+          const childFilter = config[childTable]?.where ?? true;
+          createReferentialIntegrityAssertion(
+            globalParams,
+            parentSchema,
+            parentTable,
+            parentKey,
+            parentFilter,
+            childSchema,
+            childTable,
+            childKey,
+            childFilter,
+          );
+        },
+      );
     }
-  };
+  }
   return assertions;
 };

--- a/includes/referential_integrity_assertions.js
+++ b/includes/referential_integrity_assertions.js
@@ -89,7 +89,7 @@ module.exports = (globalParams, config, referentialIntegrityConditions) => {
 
       relationships.forEach(
         ({ parentKey, childSchema, childTable, childKey }) => {
-          const childFilter = config[childTable]?.where ?? true;
+          const childFilter = config[childSchema]?.[childTable]?.where ?? true;
           createReferentialIntegrityAssertion(
             globalParams,
             parentSchema,

--- a/includes/row_condition_assertions.js
+++ b/includes/row_condition_assertions.js
@@ -20,13 +20,25 @@
 
 const assertions = [];
 
-const createRowConditionAssertion = (globalParams, schemaName, tableName, filter, conditionName, conditionQuery) => {
-  const assertion = assert(`assert_${conditionName.replace(/-/g , "_")}_${schemaName}_${tableName}`)
+const createRowConditionAssertion = (
+  globalParams,
+  schemaName,
+  tableName,
+  filter,
+  conditionName,
+  conditionQuery,
+) => {
+  const assertion = assert(
+    `${schemaName}_${tableName}_assertions_${conditionName.replace(/-/g, "_")}`,
+  )
     .database(globalParams.database)
     .schema(globalParams.schema)
-    .description(`Assert that rows in ${schemaName}.${tableName} meet ${conditionName}`)
+    .description(
+      `Assert that rows in ${schemaName}.${tableName} meet ${conditionName}`,
+    )
     .tags("assert-row-condition")
-    .query(ctx => `
+    .query(
+      (ctx) => `
                 WITH
                     filtering AS (
                         SELECT
@@ -39,17 +51,19 @@ const createRowConditionAssertion = (globalParams, schemaName, tableName, filter
                     SELECT "Condition not met: ${conditionQuery}, Table: ${ctx.ref(schemaName, tableName)}" AS assertion_description
                         FROM filtering
                         WHERE NOT (${conditionQuery})
-                    `);
+                    `,
+    );
 
-  (globalParams.tags && globalParams.tags.forEach((tag) => assertion.tags(tag)));
+  globalParams.tags && globalParams.tags.forEach((tag) => assertion.tags(tag));
 
-  (globalParams.disabledInEnvs && globalParams.disabledInEnvs.includes(dataform.projectConfig.vars.env)) && assertion.disabled();
+  globalParams.disabledInEnvs &&
+    globalParams.disabledInEnvs.includes(dataform.projectConfig.vars.env) &&
+    assertion.disabled();
 
   assertions.push(assertion);
 };
 
 module.exports = (globalParams, config, rowConditions) => {
-
   // Loop through rowConditions to create assertions.
   for (let schemaName in rowConditions) {
     const tableNames = rowConditions[schemaName];
@@ -63,10 +77,10 @@ module.exports = (globalParams, config, rowConditions) => {
           tableName,
           filter,
           conditionName,
-          conditionQuery
+          conditionQuery,
         );
       }
     }
   }
   return assertions;
-}
+};

--- a/index.js
+++ b/index.js
@@ -27,34 +27,56 @@ const data_completeness_assertions = require("./includes/data_completeness_asser
 const referential_integrity_assertions = require("./includes/referential_integrity_assertions");
 
 module.exports = ({
-    globalAssertionsParams = {},
-    config = {},
-    rowConditions = {},
-    uniqueKeyConditions = {},
-    dataFreshnessConditions = {},
-    dataCompletenessConditions = {},
-    referentialIntegrityConditions = {}
+  globalAssertionsParams = {},
+  config = {},
+  rowConditions = {},
+  uniqueKeyConditions = {},
+  dataFreshnessConditions = {},
+  dataCompletenessConditions = {},
+  referentialIntegrityConditions = {},
 }) => {
+  const defaultGlobalAssertionsParams = {
+    database: dataform.projectConfig.defaultDatabase,
+    schema: dataform.projectConfig.assertionSchema,
+    location: dataform.projectConfig.defaultLocation,
+    tags: [],
+    disabledInEnvs: [],
+  };
+  const mergedGlobalAssertionsParams = {
+    ...defaultGlobalAssertionsParams,
+    ...globalAssertionsParams,
+  };
+  const rowConditionAssertionsResult = row_condition_assertions(
+    mergedGlobalAssertionsParams,
+    config,
+    rowConditions,
+  );
+  const uniqueKeyAssertionsResult = unique_key_assertions(
+    mergedGlobalAssertionsParams,
+    config,
+    uniqueKeyConditions,
+  );
+  const dataFreshnessAssertionsResult = data_freshness_assertions(
+    mergedGlobalAssertionsParams,
+    config,
+    dataFreshnessConditions,
+  );
+  const dataCompletenessAssertionsResult = data_completeness_assertions(
+    mergedGlobalAssertionsParams,
+    config,
+    dataCompletenessConditions,
+  );
+  const referentialIntegrityAssertionsResult = referential_integrity_assertions(
+    mergedGlobalAssertionsParams,
+    config,
+    referentialIntegrityConditions,
+  );
 
-    const defaultGlobalAssertionsParams = {
-        database: dataform.projectConfig.defaultDatabase,
-	schema: dataform.projectConfig.assertionSchema,
-	location: dataform.projectConfig.defaultLocation,
-	tags: [],
-	disabledInEnvs: [],
-    };
-    const mergedGlobalAssertionsParams = {...defaultGlobalAssertionsParams, ...globalAssertionsParams};
-    const rowConditionAssertionsResult = row_condition_assertions(mergedGlobalAssertionsParams, config, rowConditions);
-    const uniqueKeyAssertionsResult = unique_key_assertions(mergedGlobalAssertionsParams, config, uniqueKeyConditions);
-    const dataFreshnessAssertionsResult = data_freshness_assertions(mergedGlobalAssertionsParams, config, dataFreshnessConditions);
-    const dataCompletenessAssertionsResult = data_completeness_assertions(mergedGlobalAssertionsParams, config, dataCompletenessConditions);
-    const referentialIntegrityAssertionsResult = referential_integrity_assertions(mergedGlobalAssertionsParams, config, referentialIntegrityConditions);
-
-    return {
-        rowConditionAssertions: rowConditionAssertionsResult,
-        uniqueKeyAssertions: uniqueKeyAssertionsResult,
-        dataFreshnessAssertions: dataFreshnessAssertionsResult,
-        dataCompletenessAssertions: dataCompletenessAssertionsResult,
-        referentialIntegrityAssertions: referentialIntegrityAssertionsResult
-    };
-}
+  return {
+    rowConditionAssertions: rowConditionAssertionsResult,
+    uniqueKeyAssertions: uniqueKeyAssertionsResult,
+    dataFreshnessAssertions: dataFreshnessAssertionsResult,
+    dataCompletenessAssertions: dataCompletenessAssertionsResult,
+    referentialIntegrityAssertions: referentialIntegrityAssertionsResult,
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "astercapital/dataform-assertions",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/astercapital/dataform-assertions.git"


### PR DESCRIPTION
* [Refactor] Change how dataform assertion names are build to maintain the same standard from the default dataform assertions
* [Bugfix] Fix how child table where conditions are accessed in the referential integrity assertion
* [Bugfix] Change npm package scope to astercapital